### PR TITLE
Use autotools macros instead of raw make directives for demo building

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,9 +20,6 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS	= config bindings bitmaps doc icons localized lib include tools clients tests
 
-demos:
-	@$(MAKE) -C demos
-
-clean-local:
-	@$(MAKE) -C demos clean
-
+if WITH_DEMOS
+SUBDIRS += demos
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,7 @@ AM_CONDITIONAL([XM_WITH_JPEG], test "x$with_jpeg" == "xyes")
 AM_CONDITIONAL([XM_WITH_PNG],  test "x$with_png"  == "xyes")
 AM_CONDITIONAL([XM_MSGCAT],    test "x$enable_message_catalog" == "xyes")
 AM_CONDITIONAL([WITH_GLW],     test "x$enable_glw" == "xyes")
+AM_CONDITIONAL([WITH_DEMOS],   test "x$enable_demos" == "xtrue")
 
 dnl Substitutions for lib/Xm/Xm.h
 AC_SUBST([XM_MAJOR], [_XM_MAJOR])


### PR DESCRIPTION
Makes a WITH_DEMOS macro to toggle the subdir so we don't manually call make