### PR TITLE
tests: Only build tests/ if tests are enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,8 +18,12 @@ MAINTAINERCLEANFILES = Makefile.in \
 pkgconfig_DATA  = motif.pc
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS	= config bindings bitmaps doc icons localized lib include tools clients tests
+SUBDIRS	= config bindings bitmaps doc icons localized lib include tools clients
 
 if WITH_DEMOS
 SUBDIRS += demos
+endif
+
+if WITH_TESTS
+SUBDIRS += tests
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -223,6 +223,8 @@ dnl Tests
 AC_ARG_ENABLE([tests],
 	[AS_HELP_STRING([--enable-tests], [Enable automated tests])],
 	[enable_tests=$enableval], [enable_tests=no])
+AM_CONDITIONAL([WITH_TESTS], test "x$enable_tests" == "xyes")
+
 AS_IF([test "x$enable_tests" == "xyes"],[
 	AC_PROG_AWK
 	AC_REQUIRE_AUX_FILE([tap-driver.sh])


### PR DESCRIPTION
This is consistent with WITH_DEMOS. It avoids failing with a link error if you configure without --enable-tests but do "make check" anyway; now "make check" does nothing if tests aren't enabled.

(Thanks for starting this project! It'll save a lot of patching for distributors...)