### PR TITLE
Uil.y: only enable debug symbols with debug flag

### DIFF
--- a/tools/wml/Uil.y
+++ b/tools/wml/Uil.y
@@ -49,7 +49,9 @@ int yyerror(const char *);
 
 #define		YYSTYPE		yystype
 
+#ifdef DEBUG
 #define		YYDEBUG		1
+#endif
 
 /*   Declare and initialize stack entry for epsilon productions.    */
 


### PR DESCRIPTION
I am going to break these AIX focused changes into smaller requests due to merge conflicts