### PR TITLE
tools/wml/Makefile.am: add token.dat rule for clarity

### DIFF
--- a/tools/wml/Makefile.am
+++ b/tools/wml/Makefile.am
@@ -45,8 +45,10 @@ wmlsynbld.c: wmlparse.h
 
 $(WMLTARGETS): wml-uil.mm
 
-wml-uil.mm: wmluiltok wml UilLexPars.y $(TABLE)
-	./wmluiltok <$(srcdir)/UilLexPars.y >tokens.dat
+tokens.dat: UilLexPars.y wmluiltok
+	./wmluiltok < $(srcdir)/UilLexPars.y > tokens.dat
+
+wml-uil.mm: tokens.dat wml $(TABLE)
 	./wml $(srcdir)/$(TABLE)
 
 motif.wmd: wmldbcreate


### PR DESCRIPTION
This shifts tokens.dat to its own rule despite no clear use for it.
Many of these targets I'm not even sure where they are being used like motif.wmd, but I've not looked to closely into it.