### PR TITLE
Fix AIX build

### DIFF
--- a/clients/uil/UilDefI.h
+++ b/clients/uil/UilDefI.h
@@ -188,7 +188,7 @@ typedef int boolean;
 #include "UilIODef.h"
 #include "UilDiagDef.h"
 #include "UilSarDef.h"
-#if defined(linux) || defined(__APPLE__) || defined(sun) || defined(__FreeBSD__)
+#ifndef YYSTYPE
 #define YYSTYPE yystype
 #endif
 #include "UilLexPars.h"

--- a/demos/lib/Exm/wml/Makefile.am
+++ b/demos/lib/Exm/wml/Makefile.am
@@ -25,9 +25,7 @@ Exm.wmd: wmldbcreate
 	./wmldbcreate -o $@
 
 wml-uil.mm: $(WMLDIR)/UilLexPars.y Exm.wml $(WMLDIR)/motif.wml $(top_builddir)/tools/wml/wmluiltok
-	$(RM) Exm.h
 	$(top_builddir)/tools/wml/wmluiltok < $(WMLDIR)/UilLexPars.y > tokens.dat
-	$(LN_S) $(srcdir)/Exm.wml ./Exm.h
+	$(LN_S) -f $(srcdir)/Exm.wml ./Exm.h
 	$(CPP) $(CPPFLAGS) -I$(WMLDIR) Exm.h | $(top_builddir)/tools/wml/wml
-	$(RM) Exm.h
 

--- a/demos/lib/Exm/wml/Makefile.am
+++ b/demos/lib/Exm/wml/Makefile.am
@@ -6,7 +6,7 @@ CLEANFILES           = $(BUILT_SOURCES) Exm.wmd wml.report tokens.dat      \
                        UilSymArTa.h UilSymArTy.h UilSymCSet.h UilSymCtl.h  \
                        UilSymEnum.h UilSymGen.h UilSymNam.h UilSymRArg.h   \
                        UilSymReas.h UilTokName.h UilUrmClas.h UilSymChCl.h \
-                       UilSymChTa.h
+                       UilSymChTa.h Exm.h
 WMLDIR               = $(top_srcdir)/tools/wml
 
 noinst_PROGRAMS   = wmldbcreate

--- a/tools/wml/Makefile.am
+++ b/tools/wml/Makefile.am
@@ -4,6 +4,8 @@ EXTRA_DIST = README wmllex.c wmllex.l motif.wml UilLexPars.y UilLexPars.h UilLex
 
 AM_YFLAGS = -d
 
+BUILT_SOURCES = UilLexPars.c
+
 WMLTARGETS = UilConst.h	UilKeyTab.h	 \
 	UilSymArTa.h	UilSymArTy.h	UilSymCSet.h	UilSymCtl.h \
 	UilSymEnum.h	UilSymGen.h	UilSymNam.h	UilSymRArg.h \

--- a/tools/wml/UilLexPars.y
+++ b/tools/wml/UilLexPars.y
@@ -47,8 +47,6 @@ int yyerror(const char *);
 #include "UilDefI.h"
 #include "UilCompGl.h"
 
-#define		YYSTYPE		yystype
-
 #ifdef DEBUG
 #define		YYDEBUG		1
 #endif


### PR DESCRIPTION
While defining YYSTYPE would be more intuitive in UilLexPars.y, removing it from UilDefI.h causes UilLexAna.c to fail stating that there are conflicting definitions of yylval. With this patch, motif on AIX builds without demos (will send a patch shortly) using IBM's make and IBM's yacc, so byacc is no longer necessary on AIX.