### PR TITLE
ComboBox: fix dropdown menu positioning

### DIFF
--- a/lib/Xm/ComboBox.c
+++ b/lib/Xm/ComboBox.c
@@ -1772,11 +1772,9 @@ CBDropDownList(Widget    widget,
 	    XtY(cb);
 
 	  tmp = monitor->x + monitor->width - XtWidth(CB_ListShell(cb));
-	  tmp = MIN(tmp, shell_x - monitor->x);
-	  shell_x = MAX(monitor->x, tmp);
+	  shell_x = MAX(monitor->x, MIN(tmp, shell_x));
 	  tmp = monitor->y + monitor->height - XtHeight(CB_ListShell(cb));
-	  tmp = MIN(tmp, shell_y - monitor->y);
-	  shell_y = MAX(monitor->y, tmp);
+	  shell_y = MAX(monitor->y, MIN(tmp, shell_y));
 	  FreeXmMonitorInfo(monitor);
 
 	  /* CR 8446: The shell width may have changed unexpectedly. */


### PR DESCRIPTION
When calculating the positoin of the dropdown box, don't subtract the monitor's x/y position, otherwise this always places the menu in the top-left corner of the monitor, rather than under the widget.

It looks like this was introduced in commit c343c0533d160c7a7bc90f6ca128beb46f23b6d3